### PR TITLE
Remove the conntrack NEW for new outbound connections.

### DIFF
--- a/iptables/iptables.up.rules
+++ b/iptables/iptables.up.rules
@@ -66,7 +66,7 @@ COMMIT
 -A IN_OTHER_BLACKLIST -m comment --comment "LOG blacklisted other traffic." -j LOG --log-prefix "IPTables: Bad Other IN: " --log-level 5 --log-tcp-options --log-ip-options --log-uid
 -A IN_OTHER_BLACKLIST -m comment --comment "Drop all bad packets" -j DROP
 -A IN_TCP -m comment --comment "Deal with blacklisted traffic." -m recent --update --seconds 60 --name TCP-PORTSCAN --mask 255.255.255.255 --rsource -j IN_TCP_BLACKLIST
--A IN_TCP -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 22 -m conntrack --ctstate NEW -m comment --comment "Allow SSH" -j ACCEPT
+-A IN_TCP -p tcp -m tcp --dport 22 -m conntrack --ctstate NEW -m comment --comment "Allow SSH" -j ACCEPT
 -A IN_TCP -p tcp -m tcp --dport 5353 -m comment --comment "Allow LLMR" -j ACCEPT
 -A IN_TCP_BLACKLIST -m comment --comment "PCAP blacklisted incoming TCP traffic." -j NFLOG --nflog-prefix  "IPTables: Bad TCP IN: " --nflog-group 1
 -A IN_TCP_BLACKLIST -m comment --comment "Drop all bad packets" -j DROP
@@ -76,13 +76,13 @@ COMMIT
 -A IN_UDP_BLACKLIST -m comment --comment "PCAP blacklisted incoming UDP traffic." -j NFLOG --nflog-prefix  "IPTables: Bad UDP IN: " --nflog-group 1
 -A IN_UDP_BLACKLIST -m comment --comment "Drop all bad packets" -j DROP
 -A OUT_ICMP -p icmp -m comment --comment "Allow out going echo-request packets" -m icmp --icmp-type 8 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_TCP -p tcp -m comment --comment "Allow HTTP" -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 80 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_TCP -p tcp -m comment --comment "Allow HTTPS" -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 443 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_TCP -p tcp -m comment --comment "Allow SSH" -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 22 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_TCP -p tcp -m comment --comment "Allow DNS" -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_TCP -p tcp -m comment --comment "Allow git protocol" -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 9418 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_TCP -p tcp -m comment --comment "Allow GPG" -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m tcp --dport 11371 -m conntrack --ctstate NEW -j ACCEPT
--A OUT_UDP -p udp -m comment --comment "Allow DNS" -m udp --dport 53 -m conntrack --ctstate NEW -j ACCEPT
+-A OUT_TCP -p tcp -m comment --comment "Allow HTTP" -m tcp --dport 80 -j ACCEPT
+-A OUT_TCP -p tcp -m comment --comment "Allow HTTPS" -m tcp --dport 443 -j ACCEPT
+-A OUT_TCP -p tcp -m comment --comment "Allow SSH" -m tcp --dport 22 -j ACCEPT
+-A OUT_TCP -p tcp -m comment --comment "Allow DNS" -m tcp --dport 53 -j ACCEPT
+-A OUT_TCP -p tcp -m comment --comment "Allow git protocol" -m tcp --dport 9418 -j ACCEPT
+-A OUT_TCP -p tcp -m comment --comment "Allow GPG" -m tcp --dport 11371 -j ACCEPT
+-A OUT_UDP -p udp -m comment --comment "Allow DNS" -m udp --dport 53 -j ACCEPT
 -A OUT_UDP -p udp -m udp --dport 137 -m comment --comment "Allow NetBIOS name resolution." -j ACCEPT
 -A OUT_UDP -p udp -m udp --dport 5353 -m comment --comment "Allow mDNS" -j ACCEPT
 COMMIT


### PR DESCRIPTION
This commit removes the restriction that new outbound connections must be recognized as `NEW` by the conntrack module. Under various circumstances this restriction will incorrectly block valid outbound connections.

Additionally this commit disables the requirement that outbound TCP connection of which conntrack is unaware exclusively have the `SYN` flag set. Similarly to the aforementioned issue with conntrack and `ctstate NEW`, this rule, while semantically correct, will block valid outbound traffic under certain circumstances.

Most of these circumstances seem to relate to conntrack forgetting about the connection, possibly due to exhaustion of some internal caching data structure, reuse of ephemeral ports, or restarts of the firewall while connections are active.